### PR TITLE
Solution #2 in section 4.1 may not work

### DIFF
--- a/DNS-Integration-Scenarios/README.md
+++ b/DNS-Integration-Scenarios/README.md
@@ -221,10 +221,10 @@ The final key scenario to consider is how can an On-Premises DNS server can be p
   **Cons**:
     - All name resolution to PaaS Services will use this Conditional Forwarder and they will be redirected to Custom DNS server in Azure.
 
-- **Solution 2** - Conditional Forwarder to Specific PaaS service FQDN using Private Endpoint pointing to custom DNS IP in Azure.
+- **Solution 2** - Conditional Forwarder to Specific PaaS Private Link service FQDN using Private Endpoint pointing to custom DNS IP in Azure.
 
   Example: 
-  Conditional Forwarder to: gbbstg1.blob.core.windows.net
+  Conditional Forwarder to: gbbstg1.privatelink.blob.core.windows.net
   Pointing to IP: 10.0.0.10 (IP of Azure Custom DNS server).
 
   **Note**: You can add multiple destination IPs for the same Conditional Forwarder Zone for redundancy. Specifying a secondary Azure DNS Server IP, for example.


### PR DESCRIPTION
In my testing, using an FQDN name for the conditional forwarding on premises required to use the privatelink name, not the real FQDN.  In my testing this configuration (conditional forwarding set to real FQDN, which forwarded to custom DNS server in Azure) got the correct private response the first time, and then the public address every query after.  If the privatelink name is used for the conditional forwarder, then every query works as intended.